### PR TITLE
Tiny new default reporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "test": "node ./src/test.test.js",
-    "watch": "npx onchange -i 'package.json' './src/*.*' -- node ./src/test.test.js"
+    "watch": "npx onchange -i 'package.json' './src/**/*.*' -- node ./src/test.test.js"
   },
   "keywords": [],
   "author": "Tomas Cristian",

--- a/src/reporters/default.js
+++ b/src/reporters/default.js
@@ -1,0 +1,21 @@
+export default report;
+
+async function report(runningTests, startTime) {
+  console.log("\nRunning...");
+  await printSequentially(runningTests);
+  console.log(`Ran in: ${Date.now() - startTime}ms`);
+}
+
+async function printSequentially(runningTests) {
+  for await (const result of runningTests) {
+    print(result);
+  }
+}
+
+function print(result) {
+  const { error, title } = result;
+  console.log(`${error ? "✗" : "✓"}  ${title}`);
+  if (error) {
+    console.log(error.stack);
+  }
+}

--- a/src/reporters/default.js
+++ b/src/reporters/default.js
@@ -1,21 +1,63 @@
-export default report;
+import path from "path";
 
-async function report(runningTests, startTime) {
-  console.log("\nRunning...");
-  await printSequentially(runningTests);
-  console.log(`Ran in: ${Date.now() - startTime}ms`);
+export default async function report(runningTests, startTime) {
+  console.log("");
+  const summary = await reportSequentially(runningTests);
+  const { failCount, passCount, endTime } = summary;
+  const ok = color.green(`✓ ${passCount}`);
+  const notOk = failCount ? color.red(`✗ ${failCount}`) : "";
+  const runTime = color.grey(`Ran in ${endTime - startTime}ms`);
+  console.log(`\n${ok} ${notOk} ${runTime}`);
 }
 
-async function printSequentially(runningTests) {
+async function reportSequentially(runningTests) {
+  let failCount = 0;
   for await (const result of runningTests) {
-    print(result);
+    if (result.error) {
+      failCount++;
+      console.log(formatTestFailure(result));
+    }
   }
+  return { failCount, passCount: runningTests.length - failCount, endTime: Date.now() };
 }
 
-function print(result) {
+function formatTestFailure(result) {
   const { error, title } = result;
-  console.log(`${error ? "✗" : "✓"}  ${title}`);
-  if (error) {
-    console.log(error.stack);
+  const { message, stack, operator } = error;
+  const header = color.red(`✗ ${title}`);
+  const path = color.grey(getFilePath(stack));
+  const errorMsg = formatMessage(message, operator);
+  return `${header}\n${path}\n${errorMsg}`;
+}
+
+function getFilePath(stack) {
+  const absolute = stack.match(/^ *at.*\(file:\/\/(.*?)\)/m)[1];
+  return path.relative(process.cwd(), absolute);
+}
+
+function formatMessage(message, operator) {
+  if (operator === "deepStrictEqual") {
+    return message.split("\n").slice(3).join("\n");
   }
+  if (operator === "strictEqual") {
+    return message.replace(/\n\n/g, "\n");
+  }
+  return message;
+}
+
+const color = {
+  red: wrapIn(31),
+  green: wrapIn(32),
+  grey: wrapIn(90),
+};
+
+// TODO: consider checking for color support in terminal
+function wrapIn(colorCode) {
+  return (str) => wrapInSGR(str, colorCode);
+}
+
+function wrapInSGR(str, parameters) {
+  const csi = "\u001b[";
+  const reset = csi + 0 + "m";
+  return csi + parameters + "m" + str + reset;
 }

--- a/src/reporters/tap.js
+++ b/src/reporters/tap.js
@@ -1,0 +1,17 @@
+export default async function report(runningTests, startTime) {
+  const lines = ["TAP version 13"];
+  lines.push(`1..${runningTests.length}`);
+  let testCount = 0;
+  for await (const result of runningTests) {
+    testCount++;
+    const { error, title } = result;
+    lines.push(`${error ? "not ok" : "ok"} ${testCount} ${title}`);
+    if (error) {
+      lines.push("---");
+      lines.push(error.stack);
+      lines.push("...");
+    }
+  }
+  lines.push(`# Ran in: ${Date.now() - startTime}ms`);
+  console.log(lines.join("\n"));
+}

--- a/src/test.js
+++ b/src/test.js
@@ -1,4 +1,5 @@
 import assert from "assert";
+import report from "./reporters/default.js";
 
 export default addTest;
 
@@ -34,24 +35,4 @@ function runTest(test) {
     is: assert.strictEqual
   };
   return test.implementation(t);
-}
-
-async function report(runningTests, startTime) {
-  console.log("\nRunning...");
-  await printSequentially(runningTests);
-  console.log(`Ran in: ${Date.now() - startTime}ms`);
-}
-
-async function printSequentially(runningTests) {
-  for await (const result of runningTests) {
-    print(result);
-  }
-}
-
-function print(result) {
-  const { error, title } = result;
-  console.log(`${error ? "✗" : "✓"}  ${title}`);
-  if (error) {
-    console.log(error.stack);
-  }
 }

--- a/src/test.test.js
+++ b/src/test.test.js
@@ -33,3 +33,7 @@ test("Keeps running tests after a failed test", t => {
     t.assert(true);
   });
 }
+
+test("Displays pretty diff", t => {
+  t.deepEqual({ a: "a", b: "b" }, { a: "notA", b: "b" });
+});


### PR DESCRIPTION
The idea is to have something that does not get in the way when doing TDD.
If all tests pass one line of output is enough.
If some tests fail, I don't want to scroll the console window for two hours. I just need the name of the test, the location (that I can click on to jump straight to the offending line in my editor) and the bare minimum info to see what went wrong.

It's still a WIP but this is how the new reporter looks right now:

![outut](https://user-images.githubusercontent.com/6673901/81831274-28ce2980-950b-11ea-9577-159dff58141c.png)
